### PR TITLE
Raise events for drone creation so other mods can hook into it

### DIFF
--- a/script/mining_depot.lua
+++ b/script/mining_depot.lua
@@ -182,7 +182,8 @@ function mining_depot:spawn_drone()
     name = name,
     position = self:get_spawn_position(),
     force = entity.force,
-    create_build_effect_smoke = false
+    create_build_effect_smoke = false,
+    raise_built = true
   }
   local surface = entity.surface
   if not surface.can_place_entity(spawn_entity_data) then return end
@@ -669,7 +670,7 @@ function mining_depot:return_drone(drone)
   self:remove_drone(drone)
   drone:remove_from_list()
   drone:clear_inventory(true)
-  drone.entity.destroy()
+  drone.entity.destroy({raise_destroy = true})
   self:update_sticker()
 end
 


### PR DESCRIPTION
In the case other mods want to add/limit the amount of drones there currently is no method to easily limit the amount of drones.
With the raise events its rather easy to monitor/control the amount of drones.