### PR TITLE
Smoother drone spawning with very high draw at high bonus levels

### DIFF
--- a/script/mining_depot.lua
+++ b/script/mining_depot.lua
@@ -716,7 +716,7 @@ function mining_depot:get_full_ratio()
   local item = self.item
   if not item then return 1 end
   local productivity = 1 + mining_technologies.get_productivity_bonus(self.force_index)
-  return inventory.get_item_count(item) / ceil(self.output_amount * productivity)
+  return inventory.get_item_count(item) / min(48000, ceil(self.output_amount * productivity))
 end
 
 function mining_depot:handle_path_request_finished(event)

--- a/script/mining_depot.lua
+++ b/script/mining_depot.lua
@@ -715,7 +715,8 @@ function mining_depot:get_full_ratio()
   local inventory = self:get_output_inventory()
   local item = self.item
   if not item then return 1 end
-  return inventory.get_item_count(item) / self.output_amount
+  local productivity = 1 + mining_technologies.get_productivity_bonus(self.force_index)
+  return inventory.get_item_count(item) / ceil(self.output_amount * productivity)
 end
 
 function mining_depot:handle_path_request_finished(event)


### PR DESCRIPTION
If you pull a high amount out (for example 5+ modded belts moving 75 items/s) from a mining depot at high infinite bonus research levels, it gets into a heavily oscillating behaviour:

- when the depot is empty, all drones get sent out in a few waves over the course of a few seconds
- when those drones return, the depot inventory quickly fills up beyond the regular output slot and into the overflow thanks to productivity bonus
- due to being "overfull" the returned drones don't get sent out again, active drone count quickly drops to zero (or near zero)
- as the depot empties, once the overflow slot is empty it starts sending out drones again, however the ramp up isn't quick enough/starts to late to counter the high draw on the buffer and the output slots empty before drones start returning to the depot, leading to gaps in the output belts
- as the drones return buffers fill up and overflow very quickly again, leading to the cyclic oscillations

Changing the way the mod calculates the target buffer content for the drone spawning algorithm to take the productivity bonus into account produces a much more stable behaviour at those high bonus levels and high draw without negatively affecting behaviour at no or low bonus levels. This can be accomplished by modifying the mining_depot:get_full_ratio() method, as done in this pull request.