### PR TITLE
Add omnimatter_compression as hidden dependency

### DIFF
--- a/info.json
+++ b/info.json
@@ -6,6 +6,6 @@
   "contact": "",
   "homepage": "",
   "description": "Adds mining drones and mining depots",
-  "dependencies": ["base >= 1.1.0", "(?)DirtyMining", "(?)shrek"],
+  "dependencies": ["base >= 1.1.0", "(?)DirtyMining", "(?)omnimatter_compression", "(?)shrek"],
   "factorio_version": "1.1"
 }


### PR DESCRIPTION
Omnimatter compression (https://mods.factorio.com/mod/omnimatter_compression) adds compressed resources in data-final-fixes which currently breaks mining drones compatibility of mining those since mining drones loads before omnimatter compression.
Adding omnimatter_compression as hidden dependency fixes that.

